### PR TITLE
Update protobufs for consensus

### DIFF
--- a/consensus_messages.proto
+++ b/consensus_messages.proto
@@ -49,8 +49,6 @@ message ConsensusMessage {
    bytes header_signature = 2;
 }
 
-message ConsensusSeal { 
-  // That should be equal to header_signature of previous block.
-  bytes previous_id = 1;
+message ConsensusSeal {
   repeated ConsensusMessage previous_cert_votes = 2;
 }

--- a/consensus_messages.proto
+++ b/consensus_messages.proto
@@ -22,11 +22,11 @@ message ConsensusMessagePayload {
   // header_signature of block that was proposal
   string proposal_id = 2;
   
-  // address of node in hex format (Account family name) that propose this header_signature
+  // public_key of node in hex format that propose this header_signature
   string voter_id = 3;
 }
 
-message ConsensusMessage {
+message ConsensusMessageHeader {
 // All kind of consensus messages
   enum Type {
       VALUE_PROPOSAL = 0;
@@ -40,4 +40,17 @@ message ConsensusMessage {
   
   // payload of message
   ConsensusMessagePayload payload = 2;
+}
+
+message ConsensusMessage {
+   ConsensusMessageHeader header = 1;
+   
+   // Signature of header by voter private key
+   bytes header_signature = 2;
+}
+
+message ConsensusSeal { 
+  // That should be equal to header_signature of previous block.
+  bytes previous_id = 1;
+  repeated ConsensusMessage previous_cert_votes = 2;
 }


### PR DESCRIPTION
- Changed that voter_id at now is public key of voter (not an address of voter)
- Changed ConsensusMessage to ConsensusMessageHeader
- Provided ConsensusMessage that provide header and signature of header
- Provided ConsensusSeal, which will be stored in blockchain and proves why previous block was stored in it.