### PR TITLE
WIP: Add share proto

### DIFF
--- a/node_account.proto
+++ b/node_account.proto
@@ -15,6 +15,18 @@
 
 syntax = "proto3";
 
+message ShareInfo {
+    // prev block number before share distribution
+    uint64 block_num = 1;
+    // share which is used for frost (percent * div factor)
+    uint64 frozen_share = 2;
+    uint64 reward = 3;
+    // timestamp of prev block
+    uint64 block_timestamp = 4;
+    // months that were defrosted (from 1 to 12, 12 not need to defrost)
+    uint32 defrost_months = 5;
+}
+
 message NodeAccount {
     uint64 balance = 1;
 
@@ -36,6 +48,9 @@ message NodeAccount {
         bool min = 5;
         bool max = 6;
     }
+    // latest time where frozen balance was defrosted on user demand
+    uint64 last_defrost_timestamp = 7;
+    repeated ShareInfo shares = 8;
 }
 
 message NodeState {


### PR DESCRIPTION
Short description (some parts of business logic were skipped, only logic which uses current protobufs)

Reward handler:
1. We create a ShareInfo object when we do reward;
2. We add a timestamp of share and reward were it was created/added to ShareInfo object;
3. Then store it to NodeAccount object;

Defrost handler:
1. We took all shares that took a time of 1/2/3...12 month or more from current time at the moment of TP execution, and do a defrost process;
2. Update ShareInfo(s).defrost_months that it was processed depend of month count;
3. Placing timestamp when they were processed;

Plus:
- quick way implementation;
- storing ShareInfo(s) could be effective in the future to rollback some shares back to the frozen state if something was wrong in calculations;

Minus:
- O(n of shares * t) algorithm and we do not know, how many ShareInfo(s) we will have;
- Possible it will eat sufficient space in lmbd if we will have many master nodes in exploitation;
- Deserialization of master NodeAccount will be slower per time;
